### PR TITLE
version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@paysera/http-client-common",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paysera/http-client-common",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Axios requests wrapper",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
2.4.0 was published with .idea folder... 2.4.0 version has now been unpublished and of course npm doesn't allow publish same version...