### PR TITLE
resend request fix, tests for cancellationTokenSource property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1]
+### Changed
+- create of `cancellationTokenSource` moved a little below
+- when `JWTAuthenticationMiddleware.onResponseError` calls `resendRequest`, it provides only necessary data
+
 ## [2.6.0]
 ### Added
 - `File` entity was added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paysera/http-client-common",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Axios requests wrapper",
   "main": "dist/main.js",
   "scripts": {

--- a/src/__tests__/ClientWrapper.test.js
+++ b/src/__tests__/ClientWrapper.test.js
@@ -11,6 +11,29 @@ beforeEach(() => {
 });
 
 describe('ClientWrapper', () => {
+    test.each([
+        ['performRequest', clientWrapper => clientWrapper.performRequest.bind(clientWrapper)],
+        ['performBaseRequest', clientWrapper => clientWrapper.performBaseRequest.bind(clientWrapper)],
+    ])(
+        'returned value of `%s` has `cancellationTokenSource` property',
+        (title, makeRequest) => {
+            const clientWrapper = createClientWrapper();
+
+            nock(config.HOST)
+                .get('/list')
+                .reply(200, 'data');
+
+            const response = makeRequest(clientWrapper)(createRequest(
+                'get',
+                '/list',
+            ));
+
+            expect(response).toHaveProperty('cancellationTokenSource');
+
+            return response;
+        },
+    );
+
     test('makes request and return response', async () => {
         const clientWrapper = createClientWrapper();
 

--- a/src/service/authentication/JWTAuthenticationMiddleware.js
+++ b/src/service/authentication/JWTAuthenticationMiddleware.js
@@ -35,13 +35,16 @@ export default class JWTAuthenticationMiddleware {
             && typeof error.response === 'object'
             && AUTH_HTTP_CODES.indexOf(error.response.status) !== -1
         ) {
-            const resendConfig = { ...error.config };
-            if (resendConfig.jwtAuthenticationConfig.retryCount < 1) {
-                resendConfig.jwtAuthenticationConfig.retryCount += 1;
-
+            const { config: { jwtAuthenticationConfig } } = error;
+            if (jwtAuthenticationConfig.retryCount < 1) {
                 await this.tokenProvider.refreshToken(this.scope);
 
-                return error.config.resendRequest(resendConfig);
+                return error.config.resendRequest({
+                    jwtAuthenticationConfig: {
+                        ...jwtAuthenticationConfig,
+                        retryCount: jwtAuthenticationConfig.retryCount + 1,
+                    },
+                });
             }
         }
 


### PR DESCRIPTION
it's not a good idea to send entire config to `resendRequest` method, as it contains a lot of unnecessary information. The worst part is that it provides a full url(baseUrl + path) to `resendRequest` and when client receives this information it concatenates own baseUrl with provided url, so in the result, it makes a request to: `baseUrl + baseUrl + path`